### PR TITLE
replace firefox developer edition

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,10 +9,13 @@
       - ssh-copy-id
     state: present
 
+- name : "Tap homebrew versions cask"
+  homebrew_tap: caskroom/versions
+
 - name: "Install from homebrew cask"
   homebrew_cask:
     name:
-      - firefoxdeveloperedition
+      - firefox-beta
       - dash # Documentations
       - keka # unarchive
       - slack # chat


### PR DESCRIPTION
@Nainterceptor Firefox developer edition was removed from caskroom/versions, Mozilla intend to deprecate it 